### PR TITLE
Improve TypeScript and webpack build performance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   env: {
-    worker: true,
     es2021: true,
+    jest: true,
+    worker: true,
   },
   settings: {
     'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "jest --coverage",
     "lint": "eslint --fix src/* --ext .ts",
-    "build": "webpack"
+    "build": "webpack",
+    "prepare": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,18 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "esnext",
-    "target": "esnext",
+    "module": "ES2020",
+    "target": "ES2020",
     "moduleResolution": "node",
     "lib": [
-      "esnext",
-      "webworker"
+      "ES2020",
+      "WebWorker"
     ],
     "types": [
       "jest",
       "@cloudflare/workers-types"
     ],
+    "allowJs": false,
     "alwaysStrict": true,
     "strict": true,
     "preserveConstEnums": true,
@@ -20,6 +21,12 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "declaration": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true
   },
   "include": [
     "src/*.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
     new CleanWebpackPlugin(),
     new ESLintPlugin({
       extensions: ['ts'],
+      cache: true,
     }),
   ],
   module: {
@@ -33,5 +34,11 @@ module.exports = {
         loader: 'ts-loader',
       },
     ],
+  },
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename],
+    },
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { ProgressPlugin } = require('webpack');
 
 module.exports = {
   mode: process.env.NODE_ENV || 'production',
@@ -21,6 +22,7 @@ module.exports = {
     ],
   },
   plugins: [
+    new ProgressPlugin(),
     new CleanWebpackPlugin(),
     new ESLintPlugin({
       extensions: ['ts'],
@@ -34,11 +36,5 @@ module.exports = {
         loader: 'ts-loader',
       },
     ],
-  },
-  cache: {
-    type: 'filesystem',
-    buildDependencies: {
-      config: [__filename],
-    },
   },
 };


### PR DESCRIPTION
- [x] Enable caching for `ESLintPlugin`
- [x] Update build target to `webworker` and `ES2020`
- [x] Enable `ProgressPlugin`